### PR TITLE
[#4] implement phase transitions

### DIFF
--- a/.github/ISSUES.md
+++ b/.github/ISSUES.md
@@ -2,6 +2,20 @@
 
 ## Open Issues
 
+### [Implement Phase Transitions](https://github.com/o92design/raylib_svea/issues/4)
+**Description:**  
+Implement the ability to transition between the different phases of the game (Preparation Phase, Battle Phase, Result Phase, Post-Battle Phase).
+
+**Progress:** In Progress
+
+**Acceptance Criteria:**
+- [ ] Implement the ability to transition from the Preparation Phase to the Battle Phase.
+- [ ] Implement the ability to transition from the Battle Phase to the Result Phase.
+- [ ] Implement the ability to transition from the Result Phase to the Post-Battle Phase.
+- [ ] Implement the ability to transition from the Post-Battle Phase to the Preparation Phase.
+
+---
+
 ### [Refactor Memory Management System](https://github.com/o92design/raylib_svea/issues/13)
 **Description:**  
 Refactor the memory management system to be more generic and reusable across different parts of the game.
@@ -46,20 +60,6 @@ Implement basic mouse click handling to register clicks and determine what the p
 **Acceptance Criteria:**
 - [ ] Implement functionality to register mouse clicks.
 - [ ] Determine if the player is clicking on an entity or a specific area of the screen.
-
----
-
-### [Implement Phase Transitions](https://github.com/o92design/raylib_svea/issues/4)
-**Description:**  
-Implement the ability to transition between the different phases of the game (Preparation Phase, Battle Phase, Result Phase, Post-Battle Phase).
-
-**Progress:** Open
-
-**Acceptance Criteria:**
-- [ ] Implement the ability to transition from the Preparation Phase to the Battle Phase.
-- [ ] Implement the ability to transition from the Battle Phase to the Result Phase.
-- [ ] Implement the ability to transition from the Result Phase to the Post-Battle Phase.
-- [ ] Implement the ability to transition from the Post-Battle Phase to the Preparation Phase.
 
 ---
 

--- a/.github/ISSUES.md
+++ b/.github/ISSUES.md
@@ -9,10 +9,10 @@ Implement the ability to transition between the different phases of the game (Pr
 **Progress:** In Progress
 
 **Acceptance Criteria:**
-- [ ] Implement the ability to transition from the Preparation Phase to the Battle Phase.
-- [ ] Implement the ability to transition from the Battle Phase to the Result Phase.
-- [ ] Implement the ability to transition from the Result Phase to the Post-Battle Phase.
-- [ ] Implement the ability to transition from the Post-Battle Phase to the Preparation Phase.
+- [x] Implement the ability to transition from the Preparation Phase to the Battle Phase.
+- [x] Implement the ability to transition from the Battle Phase to the Result Phase.
+- [x] Implement the ability to transition from the Result Phase to the Post-Battle Phase.
+- [x] Implement the ability to transition from the Post-Battle Phase to the Preparation Phase.
 
 ---
 

--- a/include/game_loop.h
+++ b/include/game_loop.h
@@ -1,6 +1,11 @@
 #ifndef GAME_LOOP_H
 #define GAME_LOOP_H
 
-int game_loop(void);
+#include "game_phase.h"
+
+GAME_PHASE get_current_phase(void);
+void handle_phase_transition(void);
+void switch_phase(GAME_PHASE p_phase);
+int run_game_loop(void);
 
 #endif // GAME_LOOP_H

--- a/include/game_phase.h
+++ b/include/game_phase.h
@@ -1,0 +1,11 @@
+#ifndef GAME_PHASE_H
+#define GAME_PHASE_H
+
+typedef enum {
+    PHASE_PREPARATION,
+    PHASE_BATTLE,
+    PHASE_RESULT,
+    PHASE_POST_BATTLE
+} GAME_PHASE;
+
+#endif // GAME_PHASE_H

--- a/src/game_loop.c
+++ b/src/game_loop.c
@@ -7,6 +7,66 @@
 #include "systems/sprite_loader_system.h"
 #include "systems/entity_component_system.h"
 
+// Add to struct or global state
+static GAME_PHASE currentPhase = PHASE_PREPARATION;
+
+bool is_preparation_complete(void) {
+    fprintf(stdout, "Preparation complete\n");
+    return true;
+}
+
+bool is_battle_complete(void) {
+    fprintf(stdout, "Battle complete\n");
+    return true;
+}
+
+bool is_result_complete(void) {
+    fprintf(stdout, "Result complete\n");
+    return true;
+}
+
+bool is_post_battle_complete(void) {
+    fprintf(stdout, "Post battle complete\n");
+    return true;
+}
+
+void handle_phase_transition(void) {
+    switch(currentPhase) {
+        case PHASE_PREPARATION:
+            if (is_preparation_complete()) {
+                fprintf(stdout, "Switching to battle phase\n");
+                currentPhase = PHASE_BATTLE;
+            }
+            break;
+        case PHASE_BATTLE:
+            if (is_battle_complete()) {
+                fprintf(stdout, "Switching to result phase\n");
+                currentPhase = PHASE_RESULT;
+            }
+            break;
+        case PHASE_RESULT:
+            if (is_result_complete()) {
+                fprintf(stdout, "Switching to post battle phase\n");
+                currentPhase = PHASE_POST_BATTLE;
+            }
+            break;
+        case PHASE_POST_BATTLE:
+            if (is_post_battle_complete()) {
+                fprintf(stdout, "Switching to preparation phase\n");
+                currentPhase = PHASE_PREPARATION;
+            }
+            break;
+    }
+}
+
+GAME_PHASE get_current_phase(void) {
+    return currentPhase;
+}
+
+void switch_phase(GAME_PHASE p_phase) {
+    currentPhase = p_phase;
+}
+
 // Function to run the game loop
 int run_game_loop(void) {
     EntityComponentManager* entityComponentManagerPtr = create_component_manager();
@@ -31,8 +91,45 @@ int run_game_loop(void) {
     COMPONENT_ID posIdTwo = add_position_component(entityComponentManagerPtr, positionComponentTwo);
     entityComponentManagerPtr->componentMaps[entityIdTwo].componentIds[COMPONENT_TYPE_POSITION] = posIdTwo;
 
-    while (!WindowShouldClose()) {
-        render_game(entityComponentManagerPtr);
+    bool shouldClose = false;
+
+    while (!WindowShouldClose() && !shouldClose) {
+        handle_phase_transition();
+        
+        // Render based on current phase
+            switch(currentPhase) {
+        case PHASE_PREPARATION:
+            BeginDrawing();
+            ClearBackground(BLUE);
+            DrawText("Preparation Phase", 10, 10, 20, BLACK);
+            EndDrawing();
+            WaitTime(1);
+            break;
+        case PHASE_BATTLE:
+            BeginDrawing();
+            ClearBackground(RAYWHITE);
+            DrawText("Battle Phase", 10, 10, 20, BLACK);
+            render_game(entityComponentManagerPtr);
+            EndDrawing();
+            WaitTime(1);
+            break;
+        case PHASE_RESULT:
+            BeginDrawing();
+            ClearBackground(PINK);
+            DrawText("Result Phase", 10, 10, 20, BLACK);
+            EndDrawing();
+            WaitTime(1);
+            break;
+        case PHASE_POST_BATTLE:
+            BeginDrawing();
+            ClearBackground(YELLOW);
+            DrawText("Post-Battle Phase", 10, 10, 20, BLACK);
+            EndDrawing();
+            WaitTime(1);
+            shouldClose = true;
+            break;
+    }
+        
     }
 
     destroy_component_manager(&entityComponentManagerPtr);

--- a/tests/include/suites/test_suites.h
+++ b/tests/include/suites/test_suites.h
@@ -17,4 +17,7 @@ void test_game_render(void);
 void test_add_components(void);
 void test_component_memory_management(void);
 
+// Game phase tests
+void test_phase_transitions(void);
+
 #endif // TEST_SUITES_H

--- a/tests/src/test_game_phases.c
+++ b/tests/src/test_game_phases.c
@@ -1,0 +1,26 @@
+#include <CUnit/CUnit.h>
+#include "game_phase.h"
+#include "game_loop.h"
+#include "game_initialize.h"
+
+// Test phase transitions
+void test_phase_transitions(void) {
+    CU_ASSERT(initialize_game() == 0);
+    
+    CU_ASSERT(get_current_phase() == PHASE_PREPARATION);
+    
+    // Test all phase transitions
+    switch_phase(PHASE_BATTLE);
+    CU_ASSERT(get_current_phase() == PHASE_BATTLE);
+    
+    switch_phase(PHASE_RESULT);
+    CU_ASSERT(get_current_phase() == PHASE_RESULT);
+    
+    switch_phase(PHASE_POST_BATTLE);
+    CU_ASSERT(get_current_phase() == PHASE_POST_BATTLE);
+    
+    switch_phase(PHASE_PREPARATION);
+    CU_ASSERT(get_current_phase() == PHASE_PREPARATION);
+    
+    cleanup_game();
+}

--- a/tests/src/test_runner.c
+++ b/tests/src/test_runner.c
@@ -24,10 +24,14 @@ int main() {
     CU_pSuite game_render_suite = CU_add_suite("Game Render Suite", 0, 0);
     CU_add_test(game_render_suite, "Test Game Rendering", test_game_render);
 
+    CU_pSuite game_phase_suite = CU_add_suite("Game Phase Suite", 0, 0);
+    CU_add_test(game_phase_suite, "Test Phase Transitions", test_phase_transitions);
+    
 /** 
     CU_pSuite game_loop_suite = CU_add_suite("Game Loop Suite", 0, 0);
     CU_add_test(game_loop_suite, "Test Game Loop Execution", test_game_loop);
 */    
+
 
     CU_basic_set_mode(CU_BRM_VERBOSE);
     CU_basic_run_tests();


### PR DESCRIPTION
This pull request introduces a new feature for handling phase transitions in the game, along with corresponding updates to the documentation and tests. The most important changes include the addition of phase transition logic, updates to the game loop, and new tests to verify the functionality.

### Phase Transition Implementation:

* [`include/game_phase.h`](diffhunk://#diff-e35e0a1c41bf26a20bf8b0ca4a012788181e159048d526b993d0b92baa1318adR1-R11): Added a new `GAME_PHASE` enum to represent different phases of the game.
* [`src/game_loop.c`](diffhunk://#diff-983c434f28b618d18c65c41f9c2f8f32aa5fbcf0517be9268ab2a76e4d9f48d1R10-R69): Implemented functions to handle phase transitions and updated the game loop to render based on the current phase. [[1]](diffhunk://#diff-983c434f28b618d18c65c41f9c2f8f32aa5fbcf0517be9268ab2a76e4d9f48d1R10-R69) [[2]](diffhunk://#diff-983c434f28b618d18c65c41f9c2f8f32aa5fbcf0517be9268ab2a76e4d9f48d1L34-R132)

### Documentation Updates:

* [`.github/ISSUES.md`](diffhunk://#diff-c2c2069df5f578cdabd758ea70b5ee31a456d0936e3cbf4cf1a578c1bbcb871aR5-R18): Updated the "Implement Phase Transitions" issue to reflect the progress and acceptance criteria. [[1]](diffhunk://#diff-c2c2069df5f578cdabd758ea70b5ee31a456d0936e3cbf4cf1a578c1bbcb871aR5-R18) [[2]](diffhunk://#diff-c2c2069df5f578cdabd758ea70b5ee31a456d0936e3cbf4cf1a578c1bbcb871aL52-L65)

### Testing Enhancements:

* [`tests/include/suites/test_suites.h`](diffhunk://#diff-2fcda08c3a93836711736d0271daa9581826c64cba3a51b9f335751cd503958dR20-R22): Added a declaration for the new `test_phase_transitions` function.
* [`tests/src/test_game_phases.c`](diffhunk://#diff-360f6bfe08b4e3568c10270b333c852c56d242da1ca08eabad698c0b823aae44R1-R26): Added tests to verify correct phase transitions.
* [`tests/src/test_runner.c`](diffhunk://#diff-8b885095b9dfd76fc68800b322c722d321f1f4a40fd038cfd4d292c68fc3bc12R27-R35): Added a new test suite for game phases and included the `test_phase_transitions` function.