### PR TITLE
Setup GitHub Actions for CI (#16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up dependencies
+      run: sudo apt-get install -y build-essential libraylib-dev libcunit1-dev
+
+    - name: Build project
+      run: make ci-build
+
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up dependencies
+      run: sudo apt-get install -y build-essential libraylib-dev libcunit1-dev
+
+    - name: Run tests
+      run: make ci-test
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up dependencies
+      run: sudo apt-get install -y clang-tidy
+
+    - name: Lint code
+      run: clang-tidy src/**/*.c include/**/*.h -- -Iinclude -Ilib

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,15 @@ $(OBJ_DIR)/Tests/%.o: $(TEST_SRC_DIR)/%.c
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) -c $< -o $@
 
+# CI build
+ci-build: CFLAGS += -O2 $(LIB_INCLUDES)
+ci-build: $(RELEASE_TARGET)
+
+# CI test
+ci-test: CFLAGS += -g $(LIB_INCLUDES)
+ci-test: $(TEST_TARGET)
+	./$(TEST_TARGET)
+
 # Clean build artifacts
 clean:
 	rm -rf $(OBJ_DIR) build/Debug build/Release build/Tests
@@ -80,4 +89,4 @@ run: $(DEBUG_TARGET)
 test: $(TEST_TARGET)
 	./$(TEST_TARGET)
 
-.PHONY: all clean run debug release tests test
+.PHONY: all clean run debug release tests test ci-build ci-test


### PR DESCRIPTION
Add GitHub Actions CI configuration to the repository.

* **Makefile**
  - Add `ci-build` target for building the project in CI.
  - Add `ci-test` target for running tests in CI.
  - Update `.PHONY` to include `ci-build` and `ci-test`.

* **.github/workflows/ci.yml**
  - Create a new GitHub Actions workflow file.
  - Add jobs for building the project, running tests, and linting the code.
  - Set up dependencies for each job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/o92design/raylib_svea/tree/Ci-actions?shareId=XXXX-XXXX-XXXX-XXXX).