### PR TITLE
Update test_runner.c - disable Example Test to trigger actions

### DIFF
--- a/tests/src/test_runner.c
+++ b/tests/src/test_runner.c
@@ -7,8 +7,8 @@ int main() {
     CU_initialize_registry();
 
     // Lägg till en suite för varje testfil
-    CU_pSuite example_suite = CU_add_suite("Example Suite", 0, 0);
-    CU_add_test(example_suite, "Example Test", test_example);
+    // CU_pSuite example_suite = CU_add_suite("Example Suite", 0, 0);
+    // CU_add_test(example_suite, "Example Test", test_example);
 
     CU_pSuite component_system_suite = CU_add_suite("Component System Suite", 0, 0);
     CU_add_test(component_system_suite, "Test Component Memory Management", test_component_memory_management);


### PR DESCRIPTION
This pull request includes changes to the `tests/src/test_runner.c` file, specifically within the `int main()` function. The changes involve commenting out the creation of an example test suite and its associated test case.

Testing adjustments:

* [`tests/src/test_runner.c`](diffhunk://#diff-8b885095b9dfd76fc68800b322c722d321f1f4a40fd038cfd4d292c68fc3bc12L10-R11): Commented out the `CU_add_suite` and `CU_add_test` calls for the "Example Suite" and "Example Test" to disable them.